### PR TITLE
Removed 'else if' clause for google-services.json copying

### DIFF
--- a/scripts/fcm_config_files_process.js
+++ b/scripts/fcm_config_files_process.js
@@ -50,7 +50,9 @@ var PLATFORM = {
 // Copy key files to their platform specific folders
 if (directoryExists(IOS_DIR)) {
     copyKey(PLATFORM.IOS);
-} else if (directoryExists(ANDROID_DIR)) {
+}
+
+if (directoryExists(ANDROID_DIR)) {
     copyKey(PLATFORM.ANDROID, updateStringsXml)
 }
 


### PR DESCRIPTION
This commit enables the ROOT/platforms/android/google-services.json file to ALWAYS reflect the ROOT/google-services.json even if you have an iOS project. This is particularly important if you have multiple branches in your cordova project, each one having a different a google-services.json configuration (different firebase apps). Switching between branches and then calling `cordova build` would (previously) not update the platforms/android/google-services.json to the one that is actually in the root dir of the branch. Instead it retains the old google-services.json.

This results in the wrong google-services.json being loaded into the application at build time.