### PR TITLE
Upgrades - service file copy

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -169,33 +169,6 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 // Include the iOS < 10 methods for handling notifications for when running on iOS < 10.
 // As in, even if you compile with iOS 10 SDK, when running on iOS 9 the only way to get
 // notifications is the didReceiveRemoteNotification.
-
-- (void)messaging:(nonnull FIRMessaging *)messaging
-    didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage
-    {
-      // Short-circuit when actually running iOS 10+, let notification centre methods handle the notification.
-      if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_9_x_Max) {
-          return;
-      }
-
-      NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
-
-      NSError *error;
-      NSDictionary *userInfoMutable = [userInfo mutableCopy];
-
-      if (application.applicationState != UIApplicationStateActive) {
-          NSLog(@"New method with push callback: %@", userInfo);
-
-          [userInfoMutable setValue:@(YES) forKey:@"wasTapped"];
-          NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
-                                                             options:0
-                                                               error:&error];
-          NSLog(@"APP WAS CLOSED DURING PUSH RECEPTION Saved data: %@", jsonData);
-          lastPush = jsonData;
-      }
-    }
-
-
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
 {
     // Short-circuit when actually running iOS 10+, let notification centre methods handle the notification.

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -86,7 +86,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
             // For iOS 10 display notification (sent via APNS)
             [UNUserNotificationCenter currentNotificationCenter].delegate = self;
             // For iOS 10 data message (sent via FCM)
-            [FIRMessaging messaging].remoteMessageDelegate = self;
+            [FIRMessaging messaging].delegate = self;
 #endif
         }
 

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -170,6 +170,14 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 // As in, even if you compile with iOS 10 SDK, when running on iOS 9 the only way to get
 // notifications is the didReceiveRemoteNotification.
 
+- (void)messaging:(nonnull FIRMessaging *)messaging
+    didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage;
+
+- (void)applicationReceivedRemoteMessage:
+        (nonnull FIRMessagingRemoteMessage *)remoteMessage;
+
+
+
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
 {
     // Short-circuit when actually running iOS 10+, let notification centre methods handle the notification.


### PR DESCRIPTION
This version works fine with notifications...
Still has error for data message only: 
`FIRMessaging received data-message, but FIRMessagingDelegate's-messaging:didReceiveMessage: not implemented`

Problem:
https://firebase.google.com/docs/reference/ios/firebasemessaging/api/reference/Protocols/FIRMessagingDelegate#-messagingdidreceivemessage

The method below needs to be implemented for ios 10 and higher
`- (void)messaging:(nonnull FIRMessaging *)messaging
    didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage;`

