### PR TITLE
iOS 10.0 Fix

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.h
+++ b/src/ios/AppDelegate+FCMPlugin.h
@@ -12,6 +12,4 @@
 
 @interface AppDelegate (FCMPlugin)
 
-+ (NSData*)getLastPush;
-
 @end

--- a/src/ios/AppDelegate+FCMPlugin.h
+++ b/src/ios/AppDelegate+FCMPlugin.h
@@ -10,6 +10,19 @@
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVViewController.h>
 
-@interface AppDelegate (FCMPlugin)
+#import "Firebase.h"
+
+// Copied from Apple's header in case it is missing in some cases (e.g. pre-Xcode 8 builds).
+#ifndef NSFoundationVersionNumber_iOS_9_x_Max
+#define NSFoundationVersionNumber_iOS_9_x_Max 1299
+#endif
+
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+@import UserNotifications;
+
+@interface AppDelegate (FCMPlugin) <UNUserNotificationCenterDelegate, FIRMessagingDelegate>
 
 @end
+#endif
+
+

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -31,9 +31,6 @@
 
 @implementation AppDelegate (FCMPlugin)
 
-static NSData *lastPush;
-NSString *const kGCMMessageIDKey = @"gcm.message_id";
-
 //////////////////////////////////////////////////////
 ///////////////////INITIALIZATION/////////////////////
 //////////////////////////////////////////////////////
@@ -70,7 +67,7 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
                 [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
                 }];
 
-                // For iOS 10 display notification (sent via APNS)
+                 // For iOS 10 display notification (sent via APNS)
                 [UNUserNotificationCenter currentNotificationCenter].delegate = self;
                 //For iOS 10 data message (sent direct from FCM)
                 [FIRMessaging messaging].delegate = self;

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -164,6 +164,7 @@ static NSData* lastNotification;
     if(wasTapped) {
         NSLog(@"notifyOfMessage:withTapInfo: => wasTapped = true... therefore going to store the data and send when app returns to the foreground");
         lastNotification = jsonData;
+        return;
     }
     [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
 }

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -10,27 +10,11 @@
 #import <objc/runtime.h>
 #import <Foundation/Foundation.h>
 
-#import "Firebase.h"
-
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-@import UserNotifications;
-#endif
-
 // Implement UNUserNotificationCenterDelegate to receive display notification via APNS for devices
 // running iOS 10 and above. Implement FIRMessagingDelegate to receive data message via FCM for
 // devices running iOS 10 and above.
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-@interface AppDelegate () <UNUserNotificationCenterDelegate, FIRMessagingDelegate>
-
-@end
-#endif
 
 static NSData* lastNotification;
-
-// Copied from Apple's header in case it is missing in some cases (e.g. pre-Xcode 8 builds).
-#ifndef NSFoundationVersionNumber_iOS_9_x_Max
-#define NSFoundationVersionNumber_iOS_9_x_Max 1299
-#endif
 
 @implementation AppDelegate (FCMPlugin)
 

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -16,9 +16,6 @@
 @import UserNotifications;
 #endif
 
-@import FirebaseInstanceID;
-@import FirebaseMessaging;
-
 // Implement UNUserNotificationCenterDelegate to receive display notification via APNS for devices
 // running iOS 10 and above. Implement FIRMessagingDelegate to receive data message via FCM for
 // devices running iOS 10 and above.
@@ -32,7 +29,7 @@
 #define NSFoundationVersionNumber_iOS_9_x_Max 1299
 #endif
 
-@implementation AppDelegate (MCPlugin)
+@implementation AppDelegate (FCMPlugin)
 
 static NSData *lastPush;
 NSString *const kGCMMessageIDKey = @"gcm.message_id";
@@ -50,281 +47,79 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
 }
 
 - (BOOL)application:(UIApplication *)application customDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-
+    
     [self application:application customDidFinishLaunchingWithOptions:launchOptions];
-
+    
     NSLog(@"DidFinishLaunchingWithOptions");
-
-
-    // Register for remote notifications. This shows a permission dialog on first run, to
-    // show the dialog at a more appropriate time move this registration accordingly.
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
-        // iOS 7.1 or earlier. Disable the deprecation warnings.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        UIRemoteNotificationType allNotificationTypes =
-        (UIRemoteNotificationTypeSound |
-         UIRemoteNotificationTypeAlert |
-         UIRemoteNotificationTypeBadge);
-        [application registerForRemoteNotificationTypes:allNotificationTypes];
-#pragma clang diagnostic pop
-    } else {
-        // iOS 8 or later
-        // [START register_for_notifications]
-        if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
-            UIUserNotificationType allNotificationTypes =
-            (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
-            UIUserNotificationSettings *settings =
-            [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
-            [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-        } else {
-            // iOS 10 or later
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-            UNAuthorizationOptions authOptions =
-            UNAuthorizationOptionAlert
-            | UNAuthorizationOptionSound
-            | UNAuthorizationOptionBadge;
-            [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
-            }];
-
-            // For iOS 10 display notification (sent via APNS)
-            [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-            // For iOS 10 data message (sent via FCM)
-            [FIRMessaging messaging].delegate = self;
-#endif
-        }
-
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-        // [END register_for_notifications]
-    }
-
-    // [START configure_firebase]
+    
     [FIRApp configure];
-    // [END configure_firebase]
-    // Add observer for InstanceID token refresh callback.
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRefreshNotification:)
-                                                 name:kFIRInstanceIDTokenRefreshNotification object:nil];
+    
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
+        UIUserNotificationType allNotificationTypes =
+        (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
+        UIUserNotificationSettings *settings =
+        [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
+        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    } else {
+        // iOS 10 or later
+        #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+                UNAuthorizationOptions authOptions =
+                UNAuthorizationOptionAlert
+                | UNAuthorizationOptionSound
+                | UNAuthorizationOptionBadge;
+                [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
+                }];
+
+                // For iOS 10 display notification (sent via APNS)
+                [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+                //For iOS 10 data message (sent direct from FCM)
+                [FIRMessaging messaging].delegate = self;
+        #endif
+    }
+    
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
+    [FIRMessaging messaging].shouldEstablishDirectChannel = YES;
+    
     return YES;
 }
+
+//////////////////////////////////////////////////////
+////////////////////////ALL IOS///////////////////////
+//////////////////////////////////////////////////////
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    //FORGROUND => NOTIF + DATA                         [ios 10 && ios 9]
+    //BACKGROUND.content_available=1 => NOTIF + DATA    [ios 10 && ios 9]
+    //BACKGROUND.TAPPED => NOTIF + DATA                 [ios 9]
+    //FOREGROUND => DATA                                [ios 9]
+    
+    [self notifyOfMessage:userInfo];
+    completionHandler(UIBackgroundFetchResultNewData);
+}
+
 
 
 //////////////////////////////////////////////////////
 /////////////////////////IOS 10///////////////////////
 //////////////////////////////////////////////////////
 
-// Receive displayed notifications for iOS 10 devices.
-// Note on the pragma: When compiling with iOS 10 SDK, include methods that
-//                     handle notifications using notification center.
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-
-// [START: FOREGROUND => NOTIFICATION || iOS = 10]
-// Handle incoming notification messages while app is in the foreground.
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-       willPresentNotification:(UNNotification *)notification
-         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-    NSLog(@"userNotificationCenter:willPresentNotification:withCompletionHandler()");
-    // Print message ID.
-    NSDictionary *userInfo = notification.request.content.userInfo;
-    if (userInfo[kGCMMessageIDKey]) {
-        NSLog(@"FOREGROUND => NOTIFICATION || iOS = 10: %@", userInfo[kGCMMessageIDKey]);
-    }
-
-    // Print full message.
-    NSLog(@"%@", userInfo);
-
-    NSError *error;
-    NSDictionary *userInfoMutable = [userInfo mutableCopy];
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
-                                                       options:0
-                                                         error:&error];
-    //JAVASCRIPT onNotification()
-    [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
-
-    // Change this to your preferred presentation option
-    completionHandler(UNNotificationPresentationOptionNone); //When we are in the foreground, don't display the notification
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler {
+    //BACKGROUND.TAPPED => NOTIF + DATA         [ios 10]
+    [self notifyOfMessage:response.notification.request.content.userInfo];
 }
-// [END: FOREGROUND => NOTIFICATION || iOS = 10]
 
-// [START: TAPPED => NOTIFICATION || iOS = 10]
-// Handle notification messages after display notification is tapped by the user.
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-didReceiveNotificationResponse:(UNNotificationResponse *)response
-         withCompletionHandler:(void (^)())completionHandler {
-    NSLog(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler()");
-    NSDictionary *userInfo = response.notification.request.content.userInfo;
-    if (userInfo[kGCMMessageIDKey]) {
-        NSLog(@"TAPPED => NOTIFICATION || iOS = 10: %@", userInfo[kGCMMessageIDKey]);
-    }
-
-    // Print full message.
-    NSLog(@"aaa%@", userInfo);
-
-    NSError *error;
-    NSDictionary *userInfoMutable = [userInfo mutableCopy];
-
-    NSLog(@"New method with push callback: %@", userInfo);
-    [userInfoMutable setValue:@(YES) forKey:@"wasTapped"];
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
-                                                       options:0
-                                                         error:&error];
-    
-    //Save the data so that when the app loads it can read the variable lastPush and call the onNotification() handler
-    NSLog(@"APP WAS CLOSED DURING PUSH RECEPTION Saved data: %@", jsonData);
-    lastPush = jsonData;
-
-    completionHandler();
+- (void)messaging:(nonnull FIRMessaging *)messaging didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage {
+    //FOREGROUND => DATA                        [ios 10]
+    [self notifyOfMessage:remoteMessage.appData];
 }
-// [END: TAPPED => NOTIFICATION || iOS = 10]
-
-// [START: FOREGROUND,TAPPED => DATA || iOS = 10]
-- (void)messaging:(nonnull FIRMessaging *)messaging
-didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage
-{
-    NSLog(@"messaging:didReceiveMessage:remoteMessage()");
-    // Print message ID.
-    NSDictionary *userInfo = remoteData.appData;
-    if (userInfo[kGCMMessageIDKey]) {
-        NSLog(@"FOREGROUND,TAPPED => DATA || iOS = 10: %@", userInfo[kGCMMessageIDKey]);
-    }
-    
-    // Print full message.
-    NSLog(@"%@", userInfo);
-    
-    NSError *error;
-    NSDictionary *userInfoMutable = [userInfo mutableCopy];
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
-                                                       options:0
-                                                         error:&error];
-    //JAVASCRIPT onNotification()
-    [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
-}
-// [END: FOREGROUND,TAPPED => DATA || iOS = 10]
-
-#endif
-
-
-
-//////////////////////////////////////////////////////
-///////////////////////IOS < 10///////////////////////
-//////////////////////////////////////////////////////
-
-// Include the iOS < 10 methods for handling notifications for when running on iOS < 10.
-// As in, even if you compile with iOS 10 SDK, when running on iOS 9 the only way to get
-// notifications is the didReceiveRemoteNotification.
-
-// [START: FOREGROUND,TAPPED,BACKGROUND => NOTIFICATION + DATA || iOS < 10]
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
-fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
-{
-    NSLog(@"application:didReceiveRemoteNotification:fetchCompletionHandler()");
-    // Short-circuit when actually running iOS 10+, let notification centre methods handle the notification.
-    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_9_x_Max) {
-        // check if message is a silent message
-        NSString* JSONString = [[NSString alloc] initWithBytes:[jsonData bytes] length:[jsonData length] encoding:NSUTF8StringEncoding];
-        
-        if ([JSONString rangeOfString:@"FCM_PLUGIN_ACTIVITY"].location != NSNotFound)
-            return;
-    }
-    
-    NSError *error;
-    NSDictionary *userInfoMutable = [userInfo mutableCopy];
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:userInfoMutable
-                                                       options:0
-                                                         error:&error];
-
-    // If you are receiving a notification message while your app is in the background,
-    // this callback will not be fired till the user taps on the notification launching the application.
-
-    // Print message ID.
-    NSLog(@"Message ID: %@", userInfo[@"gcm.message_id"]);
-
-    // Pring full message.
-    NSLog(@"%@", userInfo);
-
-
-    // Has user tapped the notificaiton?
-    // UIApplicationStateActive   - app is currently active
-    // UIApplicationStateInactive - app is transitioning from background to
-    //                              foreground (user taps notification)
-
-    UIApplicationState state = application.applicationState;
-    if (application.applicationState == UIApplicationStateActive || application.applicationState == UIApplicationStateInactive) {
-        
-        if(appliation.applicationState == UIApplicationStateInactive) {
-            NSLog(@"app becoming active");
-            [userInfoMutable setValue:@(YES) forKey:@"wasTapped"];
-        }
-
-        [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
-    }
-
-    completionHandler(UIBackgroundFetchResultNoData);
-}
-// [END: FOREGROUND,TAPPED => NOTIFICATION + DATA || iOS < 10]
-
-//REMOVED THE METHOD: - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo [DEPRECIATED]
-//https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623117-application?changes=latest_minor&language=objc
-
 
 //////////////////////////////////////////////////////
 ////////////////////REFRESH TOKENS////////////////////
 //////////////////////////////////////////////////////
-
-// [START: REFRESH TOKEN || iOS = 10]
-- (void)messaging:(nonnull FIRMessaging *)messaging
-didRefreshRegistrationToken:(nonnull NSString *)fcmToken
+- (void)messaging:(nonnull FIRMessaging *)messaging didRefreshRegistrationToken:(nonnull NSString *)fcmToken
 {
-    NSLog(@"iOS = 10: messaging:didRefreshRegistrationToken: InstanceID token: %@", fcmToken);
-    [FCMPlugin.fcmPlugin notifyOfTokenRefresh:refreshedToken];
-    
-    // Connect to FCM since connection may have failed when attempted before having a token.
-    [self connectToFcm];
+    [FCMPlugin.fcmPlugin notifyOfTokenRefresh:fcmToken];
 }
-// [END: REFRESH TOKEN || iOS = 10]
-
-// [START: REFRESH TOKEN || iOS < 10]
-- (void)tokenRefreshNotification:(NSNotification *)notification
-{
-    // Note that this callback will be fired everytime a new token is generated, including the first
-    // time. So if you need to retrieve the token as soon as it is available this is where that
-    // should be done.
-    NSString *fcmToken = [[FIRInstanceID instanceID] token];
-    NSLog(@"iOS < 10: tokenRefreshNotification: InstanceID token: %@", fcmToken);
-    [FCMPlugin.fcmPlugin notifyOfTokenRefresh:refreshedToken];
-    // Connect to FCM since connection may have failed when attempted before having a token.
-    [self connectToFcm];
-
-    // TODO: If necessary send token to appliation server.
-}
-// [END: REFRESH TOKEN || iOS < 10]
-
-//////////////////////////////////////////////////////
-////////////////////CONNECT TO FCM////////////////////
-//////////////////////////////////////////////////////
-
-// [START connect_to_fcm]
-- (void)connectToFcm
-{
-
-    // Won't connect since there is no token
-    if (![[FIRInstanceID instanceID] token]) {
-        return;
-    }
-
-    // Disconnect previous FCM connection if it exists.
-    [[FIRMessaging messaging] shouldEstablishDirectChannel];
-
-    [[FIRMessaging messaging] connectWithCompletion:^(NSError * _Nullable error) {
-        if (error != nil) {
-            NSLog(@"Unable to connect to FCM. %@", error);
-        } else {
-            NSLog(@"Connected to FCM.");
-            [[FIRMessaging messaging] subscribeToTopic:@"/topics/ios"];
-            [[FIRMessaging messaging] subscribeToTopic:@"/topics/all"];
-        }
-    }];
-}
-// [END connect_to_fcm]
 
 
 //////////////////////////////////////////////////////
@@ -334,25 +129,36 @@ didRefreshRegistrationToken:(nonnull NSString *)fcmToken
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
     NSLog(@"app become active");
-    [FCMPlugin.fcmPlugin appEnterForeground];
-    [self connectToFcm];
 }
 
-// [START disconnect_from_fcm]
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
     NSLog(@"app entered background");
-    [[FIRMessaging messaging] shouldEstablishDirectChannel];
-    [FCMPlugin.fcmPlugin appEnterBackground];
-    NSLog(@"Disconnected from FCM");
 }
-// [END disconnect_from_fcm]
 
-+(NSData*)getLastPush
-{
-    NSData* returnValue = lastPush;
-    lastPush = nil;
-    return returnValue;
+//////////////////////////////////////////////////////
+///////////////////MESSAGE HANDLING///////////////////
+//////////////////////////////////////////////////////
+
+-(void) notifyOfMessage: (NSDictionary*) notification {
+    NSData *jsonData = [self packageMessage:notification];
+    [self logMessage:jsonData];
+    
+    [FCMPlugin.fcmPlugin notifyOfMessage:jsonData];
+}
+
+-(void) logMessage: (NSData*) messageData {
+    NSLog(@"FCMPlugin: %@", messageData);
+}
+
+-(NSData*) packageMessage: (NSDictionary*) notification {
+    NSError *error;
+    NSDictionary *notificationMut = [notification mutableCopy];
+    
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:notificationMut
+                                                       options:0
+                                                         error:&error];
+    return jsonData;
 }
 
 

--- a/src/ios/FCMPlugin.h
+++ b/src/ios/FCMPlugin.h
@@ -14,7 +14,5 @@
 - (void)registerNotification:(CDVInvokedUrlCommand*)command;
 - (void)notifyOfMessage:(NSData*) payload;
 - (void)notifyOfTokenRefresh:(NSString*) token;
-- (void)appEnterBackground;
-- (void)appEnterForeground;
 
 @end

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -86,6 +86,7 @@ static FCMPlugin *fcmPluginInstance;
 
 -(void) notifyOfMessage:(NSData *)payload
 {
+    NSLog(@"notifyOfMessage: => executing javascript callback");
     NSString *JSONString = [[NSString alloc] initWithBytes:[payload bytes] length:[payload length] encoding:NSUTF8StringEncoding];
     NSString * notifyJS = [NSString stringWithFormat:@"%@(%@);", notificationCallback, JSONString];
     NSLog(@"stringByEvaluatingJavaScriptFromString %@", notifyJS);

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -13,7 +13,6 @@
 @implementation FCMPlugin
 
 static BOOL notificatorReceptorReady = NO;
-static BOOL appInForeground = YES;
 
 static NSString *notificationCallback = @"FCMPlugin.onNotificationReceived";
 static NSString *tokenRefreshCallback = @"FCMPlugin.onTokenRefreshReceived";
@@ -79,10 +78,6 @@ static FCMPlugin *fcmPluginInstance;
     NSLog(@"view registered for notifications");
     
     notificatorReceptorReady = YES;
-    NSData* lastPush = [AppDelegate getLastPush];
-    if (lastPush != nil) {
-        [FCMPlugin.fcmPlugin notifyOfMessage:lastPush];
-    }
     
     CDVPluginResult* pluginResult = nil;
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -112,22 +107,6 @@ static FCMPlugin *fcmPluginInstance;
     } else {
         [self.webViewEngine evaluateJavaScript:notifyJS completionHandler:nil];
     }
-}
-
--(void) appEnterBackground
-{
-    NSLog(@"Set state background");
-    appInForeground = NO;
-}
-
--(void) appEnterForeground
-{
-    NSLog(@"Set state foreground");
-    NSData* lastPush = [AppDelegate getLastPush];
-    if (lastPush != nil) {
-        [FCMPlugin.fcmPlugin notifyOfMessage:lastPush];
-    }
-    appInForeground = YES;
 }
 
 @end

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -41,7 +41,7 @@ static FCMPlugin *fcmPluginInstance;
 {
     NSLog(@"get Token");
     [self.commandDelegate runInBackground:^{
-        NSString* token = [[FIRInstanceID instanceID] token];
+        NSString* token = [FIRMessaging messaging].FCMToken;
         CDVPluginResult* pluginResult = nil;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:token];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
Still want to resolve these before we merge:
1) LN 74: Its hard to tell from the FCM documentation whether didReceiveRemoteNotification will be fired on iOS 10 as well as willPresentNotification. If it does then we need to put the 'short circuit' code back in didReceiveRemoteNotification to stop the notification being recognised twice by the plugin

2) It would seem that in iOS 10, content-available=1 messages don't work anymore. Is this correct?

2) LN:118 Might be a problem here if applicationDidBecomeActive is called before didReceiveNotificationResponse. This would result in the notification not being recognised by the plugin because of the newly implemented [self notifyOfMessage] function which stores the data instead of sending it to javascript IF wasTapped = true. Just not sure if iOS calls it before the app goes into the foreground OR when it goes into the foreground

3) I removed this code
`[[FIRMessaging messaging] subscribeToTopic:@"/topics/ios"];		
[[FIRMessaging messaging] subscribeToTopic:@"/topics/all"];`
because it is not necessary to start receiving notifications. However is it a feature of the plugin that these particular topics are automatically subscribed to?