### PR TITLE
Updated readme and slight fix for topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 
 >[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VF654BMGUPQTJ)
 
-#### Version 2.1.2 (03/06/2017)
-- Tested on Android and iOS using Cordova cli 6.4.0, Cordova android 6.0.0 and Cordova ios 4.3.1
+#### Version 3.0.0 (11/09/2017)
+- Tested on Android and iOS using Cordova cli 7.0.1, Cordova android 6.2.3 and Cordova ios 4.4.0
 - Available sdk functions: onTokenRefresh, getToken, subscribeToTopic, unsubscribeFromTopic and onNotification
 - 'google-services.json' and 'GoogleService-Info.plist' are added automatically from Cordova project root to platform folders
 - Added data payload parameter to check whether the user tapped on the notification or was received while in foreground.
+- Supports iOS 9.0 and up. For lower versions see the original project: https://github.com/fechanique/cordova-plugin-fcm
 - **Free testing server available for free! https://cordova-plugin-fcm.appspot.com**
 
 ## Installation

--- a/src/ios/AppDelegate+FCMPlugin.h
+++ b/src/ios/AppDelegate+FCMPlugin.h
@@ -23,6 +23,11 @@
 @interface AppDelegate (FCMPlugin) <UNUserNotificationCenterDelegate, FIRMessagingDelegate>
 
 @end
+#else
+
+@interface AppDelegate (FCMPlugin) <FIRMessagingDelegate>
+
+@end
 #endif
 
 

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -63,6 +63,9 @@ static NSData* lastNotification;
     
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     [FIRMessaging messaging].shouldEstablishDirectChannel = YES;
+
+    [[FIRMessaging messaging] subscribeToTopic:@"ios"];
+    [[FIRMessaging messaging] subscribeToTopic:@"all"];
     
     return YES;
 }

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -56,16 +56,14 @@ static NSData* lastNotification;
         
         // For iOS 10 display notification (sent via APNS)
         [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-        //For iOS 10 data message (sent direct from FCM)
-        [FIRMessaging messaging].delegate = self;
 #endif
     }
     
+    [FIRMessaging messaging].delegate = self;
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     [FIRMessaging messaging].shouldEstablishDirectChannel = YES;
-
-    [[FIRMessaging messaging] subscribeToTopic:@"ios"];
-    [[FIRMessaging messaging] subscribeToTopic:@"all"];
+    
+    
     
     return YES;
 }
@@ -102,11 +100,11 @@ static NSData* lastNotification;
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-  NSLog(@"userNotificationCenter:willPresentNotification:withCompletionHandler:");
-  //FOREGROUND => NOTIF + DATA                                  [ios 10]
-  [self notifyOfMessage:notification.request.content.userInfo withTapInfo:false];
-
-  completionHandler(UNNotificationPresentationOptionNone);
+    NSLog(@"userNotificationCenter:willPresentNotification:withCompletionHandler:");
+    //FOREGROUND => NOTIF + DATA                                  [ios 10]
+    [self notifyOfMessage:notification.request.content.userInfo withTapInfo:false];
+    
+    completionHandler(UNNotificationPresentationOptionNone);
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler {
@@ -114,7 +112,7 @@ static NSData* lastNotification;
     //BACKGROUND.TAPPED => NOTIF + DATA                         [ios 10]
     //BACKGROUND.content_available=1.TAPPED => NOTIF + DATA     [ios 10] content_available=1 doesn't do anything, notification is treated like a normal bg notification
     [self notifyOfMessage:response.notification.request.content.userInfo withTapInfo:true];
-
+    
     completionHandler();
 }
 

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -54,7 +54,7 @@ static FCMPlugin *fcmPluginInstance;
     NSString* topic = [command.arguments objectAtIndex:0];
     NSLog(@"subscribe To Topic %@", topic);
     [self.commandDelegate runInBackground:^{
-        if(topic != nil)[[FIRMessaging messaging] subscribeToTopic:[NSString stringWithFormat:@"/topics/%@", topic]];
+        if(topic != nil)[[FIRMessaging messaging] subscribeToTopic:topic];
         CDVPluginResult* pluginResult = nil;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:topic];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -66,7 +66,7 @@ static FCMPlugin *fcmPluginInstance;
     NSString* topic = [command.arguments objectAtIndex:0];
     NSLog(@"unsubscribe From Topic %@", topic);
     [self.commandDelegate runInBackground:^{
-        if(topic != nil)[[FIRMessaging messaging] unsubscribeFromTopic:[NSString stringWithFormat:@"/topics/%@", topic]];
+        if(topic != nil)[[FIRMessaging messaging] unsubscribeFromTopic:topic];
         CDVPluginResult* pluginResult = nil;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:topic];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
**Updated the readme.**
We should consider taking down the 'donate' stuff. Or if we can get back in touch with the original project manager we could leave it up for them.

**Topics**
Slight fix for topics, you no longer need the '/topics/' prefix according to the current API.

**Auto-subscription to Topics**
Also in a different PR it was discussed whether we needed to reimplement the automatic topic subscription to 'ios' and 'all' topics. The basis of this thought was to try and be consistent with the android side of the plugin. Android does indeed to some automatic topic subscription:

```
FirebaseMessaging.getInstance().subscribeToTopic("android");
 FirebaseMessaging.getInstance().subscribeToTopic("all");
```

And ios is meant to do the same (not actually a requirement of Firebase)
```
[[FIRMessaging messaging] subscribeToTopic:@"ios"]
[[FIRMessaging messaging] subscribeToTopic:@"all"]
```

However it turns out this is slightly tricker than we all thought. If you do it in the plugin initialiser, FCM returns an error saying that there is no device token. The reason is FCM hasn't been given a chance to load. You get this error specifically: `Cannot subscribe to topic: ios with token: (null)`

I had a brief look at [this blog post](https://stackoverflow.com/questions/37549717/cannot-receive-push-notification-on-ios-from-firebase-3-2-0-topics) and tried the suggested solution but it does not work - i am guessing due to FCM method swizzling which denies the callback from being fired directly.


We could turn swizzling off... it may solve the problem, or it may not. Nevertheless its a bit of work and debugging to do that. For now its probably okay to leave them out and perhaps take the auto-subscriptions out of the android side as well to be consistent.

The readme does not mention this 'auto-subscription' anywhere and it kind of goes against the expected behaviour of the plugin. Would be interested on your thoughts @ostownsville 

**Enabled  [FIRMessaging messaging].delegate = self for iOS 9.0**
I noticed that this code was only included in the iOS 10 preprocessor macro. Its actually needed for iOS 9 as well because even though data messages in iOS 9 don't use the message:didRecieveMessage: methods, the token refresh mechanism is actually provided though the FIRMessagingDelegate!