### PR TITLE
On iOS, don't request notification permission until FCMPlugin.requestPermissionOnIOS() is called

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -31,39 +31,20 @@ static NSData* lastNotification;
 }
 
 - (BOOL)application:(UIApplication *)application customDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    
     [self application:application customDidFinishLaunchingWithOptions:launchOptions];
-    
     NSLog(@"DidFinishLaunchingWithOptions");
     
     [FIRApp configure];
-    
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
-        UIUserNotificationType allNotificationTypes =
-        (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
-        UIUserNotificationSettings *settings =
-        [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
-        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-    } else {
-        // iOS 10 or later
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-        UNAuthorizationOptions authOptions =
-        UNAuthorizationOptionAlert
-        | UNAuthorizationOptionSound
-        | UNAuthorizationOptionBadge;
-        [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
-        }];
-        
-        // For iOS 10 display notification (sent via APNS)
-        [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-#endif
-    }
-    
+    NSLog(@"Configured Firebase");
+
     [FIRMessaging messaging].delegate = self;
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     [FIRMessaging messaging].shouldEstablishDirectChannel = YES;
-    
-    
+
+    #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+        // For iOS 10 display notification (sent via APNS)
+        [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+    #endif
     
     return YES;
 }

--- a/src/ios/FCMPlugin.h
+++ b/src/ios/FCMPlugin.h
@@ -9,6 +9,7 @@
 + (FCMPlugin *) fcmPlugin;
 - (void)ready:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;
+- (void)requestPermissionOnIOS:(CDVInvokedUrlCommand*)command;
 - (void)subscribeToTopic:(CDVInvokedUrlCommand*)command;
 - (void)unsubscribeFromTopic:(CDVInvokedUrlCommand*)command;
 - (void)registerNotification:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -110,4 +110,22 @@ static FCMPlugin *fcmPluginInstance;
     }
 }
 
+- (void) requestPermissionOnIOS:(CDVInvokedUrlCommand*)command;
+{
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
+        UIUserNotificationType allNotificationTypes =
+        (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
+        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    } else {
+        // iOS 10 or later
+#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+        UNAuthorizationOptions authOptions =
+        UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
+        [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        }];
+#endif
+    }
+}
+
 @end

--- a/www/FCMPlugin.js
+++ b/www/FCMPlugin.js
@@ -4,6 +4,11 @@ function FCMPlugin() {
 	console.log("FCMPlugin.js: is created");
 }
 
+// Show the permission pop-up on iOS,
+FCMPlugin.prototype.requestPermissionOnIOS = function() {
+    exec(function() {}, function() {}, "FCMPlugin", 'requestPermissionOnIOS', []);
+};
+
 // SUBSCRIBE TO TOPIC //
 FCMPlugin.prototype.subscribeToTopic = function( topic, success, error ){
 	exec(success, error, "FCMPlugin", 'subscribeToTopic', [topic]);


### PR DESCRIPTION
In the original repository, there have been many requests for a way to delay initialization on iOS, for example:
https://github.com/fechanique/cordova-plugin-fcm/pull/254
https://github.com/fechanique/cordova-plugin-fcm/issues/324
https://github.com/fechanique/cordova-plugin-fcm/issues/300

This pull request delays initialization on iOS until a new function is called, `FCMPlugin.requestPermissionOnIOS()`.

Happy to hear feedback -- I don't know Objective-C so I might have messed up -- however I've tested this on iOS 11 and it's working there.

Also, this is obviously a BC break, so the plugin's version would need bumped to 4.