### PR TITLE
Make the plugin more independant

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Send a push notification to a single device or topic.
 ```
 The MIT License
 
-Copyright (c) 2017 XXX XXX (XXX@XXX.com)
+Copyright (c) 2017 Christopher Palmer, Oliver Blum (chrisjpalmer@optusbet.com.au, olliblum@gmail.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,21 +1,17 @@
 # Google Firebase Cloud Messaging Cordova Push Plugin
 > Extremely easy plug&play push notification plugin for Cordova applications with Google Firebase FCM.
 
->[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VF654BMGUPQTJ)
-
-#### Version 3.0.1 (25/09/2017)
-- Tested on Android and iOS using Cordova cli 7.0.1, Cordova android 6.2.3 and Cordova ios 4.4.0
-- Available sdk functions: onTokenRefresh, getToken, subscribeToTopic, unsubscribeFromTopic and onNotification
+#### Version 3.0.2 (16/10/2017)
+- Tested on Android and iOS using Cordova cli 7.0.1, Cordova android 6.2.3 and Cordova ios 4.5.0
+- Available sdk functions: getToken(), onTokenRefresh(), subscribeToTopic(), unsubscribeFromTopic(), onNotification()
 - 'google-services.json' and 'GoogleService-Info.plist' are added automatically from Cordova project root to platform folders
 - Added data payload parameter to check whether the user tapped on the notification or was received while in foreground.
-- Supports iOS 9.0 and up. For lower versions see the original project: https://github.com/fechanique/cordova-plugin-fcm
-- **Free testing server available for free! https://cordova-plugin-fcm.appspot.com**
+- Supports iOS 9, 10 and 11. For lower versions see the original project: https://github.com/fechanique/cordova-plugin-fcm
 
 ## Installation
 Make sure you have ‘google-services.json’ for Android or  ‘GoogleService-Info.plist’ for iOS in your Cordova project root folder. You don´t need to configure anything else in order to have push notification working for both platforms, everything is magic.
 ```Bash
-cordova plugin add cordova-plugin-fcm
-
+cordova plugin add https://github.com/ostownsville/cordova-plugin-fcm.git
 ```
 
 #### Firebase configuration files
@@ -36,7 +32,6 @@ Put the downloaded file 'GoogleService-Info.plist' in the Cordova project root f
 ## Usage
 
 :warning: It's highly recommended to use REST API to send push notifications because Firebase console does not have all the functionalities. **Pay attention to the payload example in order to use the plugin properly**.  
-You can also test your notifications with the free testing server: https://cordova-plugin-fcm.appspot.com
 
 #### Receiving Token Refresh
 
@@ -62,7 +57,7 @@ FCMPlugin.getToken(function(token){
 
 ```javascript
 //FCMPlugin.subscribeToTopic( topic, successCallback(msg), errorCallback(err) );
-//All devices are subscribed automatically to 'all' and 'ios' or 'android' topic respectively.
+//No topics are subscribed to by default (this differs from the original version).
 //Must match the following regular expression: "[a-zA-Z0-9-_.~%]{1,900}".
 FCMPlugin.subscribeToTopic('topicExample');
 ```
@@ -130,13 +125,13 @@ Send a push notification to a single device or topic.
  - If the user taps the notification, the application comes to foreground and the notification data is received in the JavaScript callback.
  - If the user does not tap the notification but opens the applicacion, nothing happens until the notification is tapped.
 
- :warning: Silent notifications (ie. content-available=1) don't work on iOS 10.0 with Firebase.
+ :warning: Silent notifications (ie. content-available=1) don't work as of yet.
 
 ## License
 ```
 The MIT License
 
-Copyright (c) 2017 Felipe Echanique Torres (felipe.echanique in the gmail.com)
+Copyright (c) 2017 XXX XXX (XXX@XXX.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Put the downloaded file 'GoogleService-Info.plist' in the Cordova project root f
 
 ## Usage
 
-:warning: It's highly recommended to use REST API to send push notifications because Firebase console does not have all the functionalities. **Pay attention to the payload example in order to use the plugin properly**.  
+:warning: It's highly recommended to use REST API to send push notifications because Firebase console does not have all the functionality. **Pay attention to the payload example in order to use the plugin properly**.  
 
 #### Receiving Token Refresh
 
@@ -57,7 +57,7 @@ FCMPlugin.getToken(function(token){
 
 ```javascript
 //FCMPlugin.subscribeToTopic( topic, successCallback(msg), errorCallback(err) );
-//No topics are subscribed to by default (this differs from the original version).
+//The plugin does not automatically subscribe to the "all", "ios" OR "android" topics (this differs from the original version).
 //Must match the following regular expression: "[a-zA-Z0-9-_.~%]{1,900}".
 FCMPlugin.subscribeToTopic('topicExample');
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.0.2",
   "name": "cordova-plugin-fcm",
   "cordova_name": "Cordova FCM Push Plugin",
   "description": "Google Firebase Cloud Messaging Cordova Push Plugin",
@@ -7,12 +7,12 @@
   "repo": "",
   "issue": "",
   "author": {
-    "name": "Felipe Echanique Torres",
-    "email": "felipe.echanique@gmail.com"
+    "name": "XXX XXX",
+    "email": "XXX@XXX.com"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fechanique/cordova-plugin-fcm"
+    "url": "https://github.com/ostownsville/cordova-plugin-fcm"
   },
   "keywords": [
     "ecosystem:cordova",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repo": "",
   "issue": "",
   "author": {
-    "name": "XXX XXX",
-    "email": "XXX@XXX.com"
+    "name": "Christopher Palmer, Oliver Blum",
+    "email": "chrisjpalmer@optusnet.com.au, olliblum@gmail.com"
   },
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,15 +19,15 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-fcm"
-      version="3.0.1">
+      version="3.0.2">
     <name>FCMPlugin</name>
     <description>Cordova FCM Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova, fcm, push, plugin</keywords>
 
     <info>
-		Cordova FCM plugin v3.0.1 installed
-		For more details visit https://github.com/fechanique/cordova-plugin-fcm
+		Cordova FCM Plugin v3.0.2 installed
+		For more details visit https://github.com/ostownsville/cordova-plugin-fcm
 	</info>
 
     <js-module src="www/FCMPlugin.js" name="FCMPlugin">
@@ -35,7 +35,8 @@
     </js-module>
 
     <engines>
-	<engine name="cordova-android" version=">=4.0.0" />
+	<engine name="cordova-android" version=">=6.2.0" />
+	<engine name="cordova-ios" version=">=4.4.0" />
     </engines>
 
     <!-- ANDROID CONFIGURATION -->

--- a/src/android/FCMPlugin.java
+++ b/src/android/FCMPlugin.java
@@ -33,8 +33,6 @@ public class FCMPlugin extends CordovaPlugin {
 		super.initialize(cordova, webView);
 		gWebView = webView;
 		Log.d(TAG, "==> FCMPlugin initialize");
-		FirebaseMessaging.getInstance().subscribeToTopic("android");
-		FirebaseMessaging.getInstance().subscribeToTopic("all");
 	}
 	 
 	public boolean execute(final String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {


### PR DESCRIPTION
I wanted to get some feedback on what would be appropriate to put in the author fields and email address fields. I have removed the old maintainers details and replaced them with XXX for now. I can make another commit to fill those details in but just want some feedback first.

Also this PR removes auto-topic subscription from the Android side of the plugin.

Chris