### PR TITLE
Android update to android@6.2.3 - google-play-store 11.4.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -67,8 +67,8 @@
 				</feature>
 		</config-file>
 
-    <framework src="com.google.firebase:firebase-core:11.2.0" />
-    <framework src="com.google.firebase:firebase-messaging:11.2.0" />
+    <framework src="com.google.firebase:firebase-core:11.4.2" />
+    <framework src="com.google.firebase:firebase-messaging:11.4.2" />
 
 		<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,8 +67,10 @@
 
         <framework src="com.google.firebase:firebase-core:11.4.2" />
         <framework src="com.google.firebase:firebase-messaging:11.4.2" />
-
-		<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
+        <framework src="com.google.android.gms:play-services-auth:11.4.2" />
+        <framework src="com.google.android.gms:play-services-identity:11.4.2" />
+        <framework src="com.google.android.gms:play-services-analytics:11.4.2" />
+		    <framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
 
 		<source-file src="src/android/FCMPlugin.java" target-dir="src/com/gae/scaffolder/plugin" />
 		<source-file src="src/android/MyFirebaseMessagingService.java" target-dir="src/com/gae/scaffolder/plugin" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,15 +19,15 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-fcm"
-      version="3.0.1">
+      version="3.0.2">
     <name>FCMPlugin</name>
     <description>Cordova FCM Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova, fcm, push, plugin</keywords>
 
     <info>
-		Cordova FCM plugin v3.0.1 installed
-		For more details visit https://github.com/fechanique/cordova-plugin-fcm
+		Cordova FCM Plugin v3.0.2 installed
+		For more details visit https://github.com/ostownsville/cordova-plugin-fcm
 	</info>
 
     <js-module src="www/FCMPlugin.js" name="FCMPlugin">
@@ -35,7 +35,9 @@
     </js-module>
 
     <engines>
-	<engine name="cordova-android" version=">=4.0.0" />
+      <engine name="cordova" version=">=7.1.0"/>
+      <engine name="cordova-android" version=">=6.2.3"/>
+      <engine name="cordova-ios" version=">=4.4.0"/>
     </engines>
 
     <!-- ANDROID CONFIGURATION -->
@@ -65,11 +67,10 @@
 				</feature>
 		</config-file>
 
-        <framework src="com.google.firebase:firebase-core:11.4.2" />
-        <framework src="com.google.firebase:firebase-messaging:11.4.2" />
-        <framework src="com.google.android.gms:play-services-gcm:11.4.2" />
-        <framework src="com.google.android.gms:play-services-analytics:11.4.2" />
-		    <framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
+    <framework src="com.google.firebase:firebase-core:11.2.0" />
+    <framework src="com.google.firebase:firebase-messaging:11.2.0" />
+
+		<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
 
 		<source-file src="src/android/FCMPlugin.java" target-dir="src/com/gae/scaffolder/plugin" />
 		<source-file src="src/android/MyFirebaseMessagingService.java" target-dir="src/com/gae/scaffolder/plugin" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,8 +67,7 @@
 
         <framework src="com.google.firebase:firebase-core:11.4.2" />
         <framework src="com.google.firebase:firebase-messaging:11.4.2" />
-        <framework src="com.google.android.gms:play-services-auth:11.4.2" />
-        <framework src="com.google.android.gms:play-services-identity:11.4.2" />
+        <framework src="com.google.android.gms:play-services-gcm:11.4.2" />
         <framework src="com.google.android.gms:play-services-analytics:11.4.2" />
 		    <framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -65,8 +65,8 @@
 				</feature>
 		</config-file>
 
-        <framework src="com.google.firebase:firebase-core:+" />
-        <framework src="com.google.firebase:firebase-messaging:+" />
+        <framework src="com.google.firebase:firebase-core:11.4.2" />
+        <framework src="com.google.firebase:firebase-messaging:11.4.2" />
 
 		<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
 

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -5,7 +5,8 @@ buildscript {
         }
     dependencies {
         classpath 'com.android.tools.build:gradle:+'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.1'
+
     }
 }
 // apply plugin: 'com.google.gms.google-services'

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -1,11 +1,10 @@
 buildscript {
 	repositories {
 		jcenter()
-			maven() {
-				url 'https://maven.google.com'
-			}
+		mavenLocal()
 	}
     dependencies {
+
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.1.1'
   }

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -7,7 +7,7 @@ android {
 buildscript {
 	repositories {
             jcenter()
-			mavenLocal()
+						maven { url 'https://maven.google.com' }
         }
     dependencies {
         classpath 'com.android.tools.build:gradle:+'

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -1,14 +1,14 @@
 buildscript {
 	repositories {
 		jcenter()
-			maven {
+			mavenLocal() {
 				url 'https://maven.google.com'
 			}
+	}
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.0.0'
-
-    }
+        classpath 'com.google.gms:google-services:3.1.1'
+  }
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -6,7 +6,7 @@ buildscript {
 			}
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.1.1'
+        classpath 'com.google.gms:google-services:3.0.0'
 
     }
 }

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -4,11 +4,11 @@ buildscript {
 			mavenLocal()
         }
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
         classpath 'com.google.gms:google-services:3.1.1'
 
     }
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+//apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+apply plugin: 'com.google.gms.google-services'

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -1,8 +1,9 @@
 buildscript {
 	repositories {
-            jcenter()
-			mavenLocal()
-        }
+		jcenter()
+			maven {
+				url 'https://maven.google.com'
+			}
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.1.1'

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
 		jcenter()
-			mavenLocal() {
+			maven() {
 				url 'https://maven.google.com'
 			}
 	}

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -10,5 +10,4 @@ buildscript {
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-//apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-apply plugin: 'com.google.gms.google-services'
+apply plugin: com.google.gms.googleservices.GoogleServicesPlugin

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -4,6 +4,7 @@ buildscript {
 			mavenLocal()
         }
     dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.1.1'
 
     }

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -1,14 +1,21 @@
+android {
+	defaultConfig {
+				multiDexEnabled true
+	}
+}
+
 buildscript {
 	repositories {
-		jcenter()
-		mavenLocal()
-	}
+            jcenter()
+			mavenLocal()
+        }
     dependencies {
-
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:+'
         classpath 'com.google.gms:google-services:3.1.1'
-  }
+    }
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+ext.postBuildExtras = {
+    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+}


### PR DESCRIPTION
Android update to android@6.2.3 -> android@6.3.0 seems to have issues
 - google-play-store 11.4.2

There is a problem with google-play-store and firebase versions.
To get this all running one will need a new dependency...

cordova plugin add cordova-google-api-version --variable GOOGLE_API_VERSION=11.4.2

That plugin fixes the version issues.
There was no other solution available....

I tried a lot with android@6.3.0, that didn't work, not even with the additional plugin